### PR TITLE
Enable scrolling in layer selector

### DIFF
--- a/style.css
+++ b/style.css
@@ -304,6 +304,7 @@ div#toolbox {
 				-webkit-border-radius: 0 0 5px 5px;
 				border-radius: 0 0 5px 5px;
 				border-width: 0 1px 1px 1px;
+				overflow-y: scroll;
 			}
 
 /* @group Search Place */


### PR DESCRIPTION
The list of time stamps in the layer selector panel has become too long to fit into the panel; the _Update layer_ button is not visible, and it's not possible to select another layer for the map.

This PR fixes the problem by enabling scrolling on active `toolbox` panels.