### PR TITLE
fix layer selector in chrome browser

### DIFF
--- a/style.css
+++ b/style.css
@@ -390,6 +390,8 @@ div#searchPlace > div.content > ul.resultList {
     -moz-columns: 3 auto;
     -webkit-columns: 3 auto;
     columns: 3 auto;
+    overflow-y: auto;
+    max-height: 360px;
 }
 
 


### PR DESCRIPTION
chrome doesn't seem to do display the 3-columns layout for some reason.
This adds some scrollbars in such cases (or if the list grows too long anyway).